### PR TITLE
Add search and fetch tools for OpenAI Deep Research compliance

### DIFF
--- a/reference_mcp/server.py
+++ b/reference_mcp/server.py
@@ -1,8 +1,10 @@
 import json
 import logging
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Tuple
 from datetime import datetime, timedelta
 from dataclasses import dataclass
+from threading import Lock
+import hashlib
 
 from fastmcp import FastMCP
 
@@ -23,34 +25,97 @@ class CacheEntry:
 
 
 class SimpleCache:
-    """Simple in-memory cache with TTL support."""
+    """Thread-safe in-memory cache with TTL support."""
 
     def __init__(self, ttl_minutes: int = 10):
         self._cache: Dict[str, CacheEntry] = {}
         self._ttl = timedelta(minutes=ttl_minutes)
+        self._lock = Lock()
+        # Secondary index for ID to cache keys mapping
+        self._id_to_keys: Dict[str, set] = {}
 
     def get(self, key: str) -> Optional[Any]:
         """Get value from cache if not expired."""
-        if key in self._cache:
-            entry = self._cache[key]
-            if datetime.now() < entry.expires_at:
-                return entry.data
-            else:
-                # Clean up expired entry
-                del self._cache[key]
-        return None
+        with self._lock:
+            # Clean expired entries periodically
+            self._clean_expired_if_needed()
+
+            if key in self._cache:
+                entry = self._cache[key]
+                if datetime.now() < entry.expires_at:
+                    return entry.data
+                else:
+                    # Clean up expired entry
+                    self._remove_entry(key)
+            return None
 
     def set(self, key: str, value: Any) -> None:
         """Set value in cache with TTL."""
         expires_at = datetime.now() + self._ttl
-        self._cache[key] = CacheEntry(data=value, expires_at=expires_at)
+        with self._lock:
+            self._cache[key] = CacheEntry(data=value, expires_at=expires_at)
+
+            # Update ID index for search results
+            if key.startswith("search:") and isinstance(value, list):
+                for ref in value:
+                    ref_id = self._get_ref_id(ref)
+                    if ref_id not in self._id_to_keys:
+                        self._id_to_keys[ref_id] = set()
+                    self._id_to_keys[ref_id].add(key)
+
+    def get_by_id(self, doc_id: str) -> Optional[Tuple[str, Dict]]:
+        """Get reference by ID from any cached search result."""
+        with self._lock:
+            if doc_id in self._id_to_keys:
+                for cache_key in self._id_to_keys[doc_id]:
+                    if cache_key in self._cache:
+                        entry = self._cache[cache_key]
+                        if datetime.now() < entry.expires_at:
+                            # Find the specific reference
+                            for ref in entry.data:
+                                if self._get_ref_id(ref) == doc_id:
+                                    return cache_key, ref
+                        else:
+                            self._remove_entry(cache_key)
+            return None
 
     def clear_expired(self) -> None:
         """Remove all expired entries."""
-        now = datetime.now()
-        expired_keys = [k for k, v in self._cache.items() if v.expires_at <= now]
-        for key in expired_keys:
+        with self._lock:
+            now = datetime.now()
+            expired_keys = [k for k, v in self._cache.items() if v.expires_at <= now]
+            for key in expired_keys:
+                self._remove_entry(key)
+
+    def _clean_expired_if_needed(self) -> None:
+        """Clean expired entries periodically (every 100 accesses)."""
+        # Simple heuristic: clean every 100 cache accesses
+        if len(self._cache) > 100 and len(self._cache) % 100 == 0:
+            self.clear_expired()
+
+    def _remove_entry(self, key: str) -> None:
+        """Remove entry and update indices."""
+        if key in self._cache:
+            # Update ID index
+            if key.startswith("search:") and isinstance(self._cache[key].data, list):
+                for ref in self._cache[key].data:
+                    ref_id = self._get_ref_id(ref)
+                    if ref_id in self._id_to_keys:
+                        self._id_to_keys[ref_id].discard(key)
+                        if not self._id_to_keys[ref_id]:
+                            del self._id_to_keys[ref_id]
             del self._cache[key]
+
+    @staticmethod
+    def _get_ref_id(ref: Dict) -> str:
+        """Get stable ID for a reference."""
+        # Use existing identifiers or create hash from title
+        base_id = ref.get("doi") or ref.get("arxiv_id") or ref.get("s2_paper_id") or ref.get("dblp_key")
+        if base_id:
+            return base_id
+        # For title-based IDs, use hash to avoid collisions
+        title = ref.get("title", "")
+        return f"title_hash_{hashlib.md5(title.encode()).hexdigest()[:16]}"
 
 
 # Global cache instance
@@ -150,9 +215,16 @@ async def search(query: str, top_k: int = 10) -> list[dict]:
     """
     logger.info(f"Search tool called with query: {query}, top_k: {top_k}")
 
+    # Input validation
+    if not query or not query.strip():
+        raise ValueError("Query cannot be empty")
+    if top_k < 1 or top_k > 100:
+        raise ValueError("top_k must be between 1 and 100")
+
     try:
-        # Check cache first
-        cache_key = f"search:{query}:{top_k}"
+        # Check cache first - use hash for better collision resistance
+        query_hash = hashlib.md5(query.encode()).hexdigest()[:8]
+        cache_key = f"search:{query_hash}:{top_k}"
         cached_full_results = search_cache.get(cache_key)
 
         if cached_full_results is None:
@@ -166,10 +238,8 @@ async def search(query: str, top_k: int = 10) -> list[dict]:
         # Build lightweight results
         hits = []
         for ref in cached_full_results:
-            # Create a stable ID from available identifiers
-            ref_id = (
-                ref.get("doi") or ref.get("arxiv_id") or ref.get("s2_paper_id") or ref.get("dblp_key") or ref["title"]
-            )
+            # Use consistent ID generation with cache
+            ref_id = search_cache._get_ref_id(ref)
 
             # Create snippet from abstract or venue info
             snippet = ""
@@ -206,63 +276,61 @@ async def fetch(ids: list[str]) -> dict[str, str]:
     """
     logger.info(f"Fetch tool called with {len(ids)} IDs")
 
-    try:
-        results: dict[str, str] = {}
+    # Input validation
+    if not ids:
+        return {}
+    if len(ids) > 50:
+        raise ValueError("Cannot fetch more than 50 documents at once")
 
-        # First try to find results in cache
-        for doc_id in ids:
-            found = False
+    results: dict[str, str] = {}
 
-            # Check all cached search results
-            for key in list(search_cache._cache.keys()):
-                if key.startswith("search:"):
-                    cached_refs = search_cache.get(key)
-                    if cached_refs:
-                        for ref in cached_refs:
-                            # Match by any identifier
-                            ref_id = (
-                                ref.get("doi")
-                                or ref.get("arxiv_id")
-                                or ref.get("s2_paper_id")
-                                or ref.get("dblp_key")
-                                or ref["title"]
-                            )
-                            if ref_id == doc_id:
-                                # Format the full document
-                                bibtex = ref["bibtex"]
-                                abstract = ref.get("abstract", "")
+    for doc_id in ids:
+        try:
+            # Use optimized cache lookup
+            cache_result = search_cache.get_by_id(doc_id)
 
-                                if abstract:
-                                    results[doc_id] = f"{bibtex}\n\nAbstract:\n{abstract}"
-                                else:
-                                    results[doc_id] = bibtex
+            if cache_result:
+                _, ref = cache_result
+                # Format the full document
+                bibtex = ref["bibtex"]
+                abstract = ref.get("abstract", "")
 
-                                found = True
-                                break
-                if found:
-                    break
-
-            # If not found in cache, search for it specifically
-            if not found:
-                logger.info(f"ID {doc_id} not found in cache, searching...")
-                raw_json = await search_reference(query=doc_id, max_results=1)
-                data = json.loads(raw_json)
-
-                if data["references"]:
-                    ref = data["references"][0]
-                    bibtex = ref["bibtex"]
-                    abstract = ref.get("abstract", "")
-
-                    if abstract:
-                        results[doc_id] = f"{bibtex}\n\nAbstract:\n{abstract}"
-                    else:
-                        results[doc_id] = bibtex
+                if abstract:
+                    results[doc_id] = f"{bibtex}\n\nAbstract:\n{abstract}"
                 else:
-                    logger.warning(f"No results found for ID: {doc_id}")
+                    results[doc_id] = bibtex
+            else:
+                # If not found in cache, search for it specifically
+                logger.info(f"ID {doc_id} not found in cache, searching...")
+                try:
+                    raw_json = await search_reference(query=doc_id, max_results=1)
+                    data = json.loads(raw_json)
 
-        logger.info(f"Returning {len(results)} full documents")
-        return results
+                    if data["references"]:
+                        ref = data["references"][0]
+                        # Check if this ref matches the requested ID
+                        found_ref_id = search_cache._get_ref_id(ref)
 
-    except Exception as e:
-        logger.error(f"Error in fetch tool: {e}")
-        raise
+                        if found_ref_id == doc_id:
+                            bibtex = ref["bibtex"]
+                            abstract = ref.get("abstract", "")
+
+                            if abstract:
+                                results[doc_id] = f"{bibtex}\n\nAbstract:\n{abstract}"
+                            else:
+                                results[doc_id] = bibtex
+                        else:
+                            logger.warning(f"Found reference doesn't match requested ID: {doc_id}")
+                    else:
+                        logger.warning(f"No results found for ID: {doc_id}")
+
+                except Exception as search_error:
+                    logger.error(f"Error searching for ID {doc_id}: {search_error}")
+                    # Continue with other IDs instead of failing entire operation
+
+        except Exception as e:
+            logger.error(f"Error processing ID {doc_id}: {e}")
+            # Continue with other IDs
+
+    logger.info(f"Returning {len(results)} full documents out of {len(ids)} requested")
+    return results

--- a/reference_mcp/server.py
+++ b/reference_mcp/server.py
@@ -239,7 +239,7 @@ async def search(query: str, top_k: int = 10) -> list[dict]:
         hits = []
         for ref in cached_full_results:
             # Use consistent ID generation with cache
-            ref_id = search_cache._get_ref_id(ref)
+            ref_id = SimpleCache._get_ref_id(ref)
 
             # Create snippet from abstract or venue info
             snippet = ""
@@ -309,7 +309,7 @@ async def fetch(ids: list[str]) -> dict[str, str]:
                     if data["references"]:
                         ref = data["references"][0]
                         # Check if this ref matches the requested ID
-                        found_ref_id = search_cache._get_ref_id(ref)
+                        found_ref_id = SimpleCache._get_ref_id(ref)
 
                         if found_ref_id == doc_id:
                             bibtex = ref["bibtex"]

--- a/run_server.py
+++ b/run_server.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+import logging
 from pathlib import Path
 
 # Add project root to path
@@ -16,6 +17,10 @@ import uvicorn
 
 from reference_mcp.server import mcp
 
+# Configure logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
 
 # Minimal OAuth stub endpoints
 async def oauth_config(request):
@@ -27,6 +32,11 @@ async def register(request):
     return JSONResponse({"client_id": "public", "registration_access_token": None})
 
 
+async def health(request):
+    """Health check endpoint for Docker health checks."""
+    return JSONResponse({"status": "healthy", "service": "bibtex-mcp"})
+
+
 def main():
     """Run the MCP server with streamable-http transport."""
     # Get configuration from environment with defaults
@@ -34,11 +44,20 @@ def main():
     port = int(os.getenv("PORT", "8000"))
     log_level = os.getenv("LOG_LEVEL", "info")
 
+    logger.info(f"Starting MCP server on {host}:{port}")
+
     # Create FastMCP app with SSE
-    mcp_app = mcp.http_app(transport="sse")
+    try:
+        mcp_app = mcp.http_app(transport="sse")
+        logger.info("Successfully created MCP app with SSE transport")
+        logger.info("Available tools: search_reference, search, fetch")
+    except Exception as e:
+        logger.error(f"Failed to create MCP app: {e}")
+        raise
 
     # Create Starlette app with OAuth stub endpoints
     routes = [
+        Route("/health", health),
         Route("/.well-known/oauth-authorization-server", oauth_config),
         Mount("/", app=mcp_app),
     ]


### PR DESCRIPTION
## Summary
- Added `search` tool that returns lightweight results (id, title, snippet) for the recall step
- Added `fetch` tool that returns full BibTeX records and abstracts for the precision step  
- Implemented simple in-memory cache with 10-minute TTL to optimize performance

## Details
This PR makes the bibtex-mcp server compliant with the OpenAI Deep Research Extension specification, which requires exactly two tools: `search` and `fetch`.

The implementation:
- Wraps the existing `search_reference` functionality 
- `search` returns only metadata needed for browsing results
- `fetch` returns full document content for selected IDs
- Cache minimizes redundant API calls between search and fetch operations

## Test plan
- [ ] Test search tool returns lightweight results with proper ID, title, and snippet fields
- [ ] Test fetch tool retrieves full BibTeX and abstracts for provided IDs
- [ ] Verify cache works correctly and expires after 10 minutes
- [ ] Confirm both tools integrate properly with Deep Research clients

🤖 Generated with [Claude Code](https://claude.ai/code)